### PR TITLE
Fixed incorrect nesting of 'lighting' filter elements

### DIFF
--- a/include/svgpp/traits/attribute_type.hpp
+++ b/include/svgpp/traits/attribute_type.hpp
@@ -125,12 +125,8 @@ template<>              struct attribute_type<tag::element::glyphRef, tag::attri
 template<>              struct attribute_type<tag::element::glyphRef, tag::attribute::dy          > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::x       > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::y       > { typedef tag::type::number type; };
-template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::dx      > { typedef tag::type::number type; };
-template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::dy      > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::feSpotLight, tag::attribute::x        > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::feSpotLight, tag::attribute::y        > { typedef tag::type::number type; };
-template<>              struct attribute_type<tag::element::feSpotLight, tag::attribute::dx       > { typedef tag::type::number type; };
-template<>              struct attribute_type<tag::element::feSpotLight, tag::attribute::dy       > { typedef tag::type::number type; };
 
 template<class Element> struct attribute_type<Element, tag::attribute::numOctaves>                { typedef tag::type::integer type; };
 template<class Element> struct attribute_type<Element, tag::attribute::targetX   >                { typedef tag::type::integer type; }; 

--- a/include/svgpp/traits/attribute_type.hpp
+++ b/include/svgpp/traits/attribute_type.hpp
@@ -123,6 +123,8 @@ template<>              struct attribute_type<tag::element::glyphRef, tag::attri
 template<>              struct attribute_type<tag::element::glyphRef, tag::attribute::y           > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::glyphRef, tag::attribute::dx          > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::glyphRef, tag::attribute::dy          > { typedef tag::type::number type; };
+template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::x       > { typedef tag::type::number type; };
+template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::y       > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::dx      > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::fePointLight, tag::attribute::dy      > { typedef tag::type::number type; };
 template<>              struct attribute_type<tag::element::feSpotLight, tag::attribute::x        > { typedef tag::type::number type; };

--- a/include/svgpp/traits/child_element_types.hpp
+++ b/include/svgpp/traits/child_element_types.hpp
@@ -327,10 +327,11 @@ struct child_element_types<tag::element::switch_, void>
 };
 
 template<class ElementTag>
-struct child_element_types<ElementTag, typename boost::enable_if<boost::mpl::has_key<boost::mpl::set12<
+struct child_element_types<ElementTag, typename boost::enable_if<boost::mpl::has_key<boost::mpl::set14<
   tag::element::feBlend, tag::element::feColorMatrix, tag::element::feComposite, tag::element::feConvolveMatrix, 
-  tag::element::feDisplacementMap, tag::element::feGaussianBlur, tag::element::feMergeNode, tag::element::feMorphology, 
-  tag::element::feOffset, tag::element::feSpotLight, tag::element::feTile, tag::element::feTurbulence>, ElementTag> >::type>
+  tag::element::feDisplacementMap, tag::element::feDistantLight, tag::element::feGaussianBlur, tag::element::feMergeNode,
+  tag::element::feMorphology, tag::element::feOffset, tag::element::fePointLight, tag::element::feSpotLight,
+  tag::element::feTile, tag::element::feTurbulence>, ElementTag> >::type>
 {
   typedef 
     boost::mpl::set2<

--- a/include/svgpp/traits/element_groups.hpp
+++ b/include/svgpp/traits/element_groups.hpp
@@ -81,8 +81,8 @@ typedef boost::mpl::set16<
 > filter_primitive_elements;
 
 typedef boost::mpl::set3<
-  tag::element::feDiffuseLighting,
-  tag::element::feSpecularLighting,
+  tag::element::feDistantLight,
+  tag::element::fePointLight,
   tag::element::feSpotLight
 > light_source_elements;
 


### PR DESCRIPTION
SVG++ incorrectly lists feSpecularLighting and feDiffuseLighting as light_source_elements, which implies that feSpecularLighting can contain another feSpecularLighting. This is an obvious typo, as fePointLight and feDistantLight are missing from the list of light_source_elements. Adding them revealed two other places where fePointLight and feDistantLight support was missing.