### PR TITLE
Strip double quotes surrounding IRIs

### DIFF
--- a/include/svgpp/parser/grammar/iri.hpp
+++ b/include/svgpp/parser/grammar/iri.hpp
@@ -28,9 +28,14 @@ public:
 
     // TODO: More thorough RFC 3987 check
     rule_
-        =   -qi::lit('"')
-            >> qi::raw[ + (!( char_(')') | char_('"')) >> char_) ]
-            >> -qi::lit('"' );
+        =
+#ifdef SVGPP_ACCEPT_QUOTED_IRI
+            (qi::lit('"')
+            >> qi::raw[ + (!(char_(')') | char_('"')) >> char_) ]
+            >> qi::lit('"' ))
+            |
+#endif
+            qi::raw[ + (!char_(')') >> char_) ];
   }
 
 private:

--- a/include/svgpp/parser/grammar/iri.hpp
+++ b/include/svgpp/parser/grammar/iri.hpp
@@ -27,7 +27,10 @@ public:
     using detail::character_encoding_namespace::char_;
 
     // TODO: More thorough RFC 3987 check
-    rule_ = qi::raw[ + (!char_(')') >> char_) ];
+    rule_
+        =   -qi::lit('"')
+            >> qi::raw[ + (!( char_(')') | char_('"')) >> char_) ]
+            >> -qi::lit('"' );
   }
 
 private:

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable( ParserGTest
   urange_grammar_test.cpp 
   value_parser_test.cpp
   value_parser_length_test.cpp 
+  value_parser_paint_ie_test.cpp 
   value_parser_paint_test.cpp 
 	value_parser_path_test.cpp 
 	value_parser_transform_test.cpp 

--- a/src/test/value_parser_paint_ie_test.cpp
+++ b/src/test/value_parser_paint_ie_test.cpp
@@ -1,0 +1,96 @@
+#define SVGPP_ACCEPT_QUOTED_IRI
+
+#include <svgpp/parser/paint.hpp>
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+namespace
+{
+  using namespace svgpp;
+
+  class Context
+  {
+  public:
+    std::string str() const { return str_.str(); }
+
+    void set(tag::attribute::stroke, tag::value::none)
+    {
+      str_ << "[none]";
+    }
+
+    void set(tag::attribute::stroke, tag::value::currentColor)
+    {
+      str_ << "[currentColor]";
+    }
+
+    void set(tag::attribute::stroke, int rgb, tag::skip_icc_color = tag::skip_icc_color())
+    {
+      str_ << "[rgb:" << std::hex << std::setw(6) << std::setfill('0') << rgb << "]";
+    }
+
+    typedef boost::iterator_range<std::string::const_iterator> iri_t;
+
+    void set(tag::attribute::stroke, iri_t const & iri)
+    {
+      str_ << "[iri:" << iri << "]";
+    }
+
+    void set(tag::attribute::stroke, iri_t const & iri, tag::value::none)
+    {
+      str_ << "[iri:" << iri << "[none]]";
+    }
+
+    void set(tag::attribute::stroke, iri_t const & iri, tag::value::currentColor)
+    {
+      str_ << "[iri:" << iri << "[currentColor]]";
+    }
+
+    void set(tag::attribute::stroke, iri_t const & iri, int rgb, tag::skip_icc_color = tag::skip_icc_color())
+    {
+      str_ << "[iri:" << iri 
+        << "[rgb:" << std::hex << std::setw(6) << std::setfill('0') << rgb << "]]";
+    }
+
+  private:
+    std::ostringstream str_;
+  };
+
+  typedef std::pair<const char *, const char *> valid_case_t;
+
+  valid_case_t ValidTests[] = {
+    valid_case_t("none", "[none]"),
+    valid_case_t("currentColor", "[currentColor]"),
+    valid_case_t("inherit", ""),
+    valid_case_t("rgb(11,12,240)", "[rgb:0b0cf0]"),
+    // All of the existing url cases - without surrounding quotes - should still pass
+    valid_case_t("url(http://aa/b)", "[iri:http://aa/b]"),
+    valid_case_t("url(http://aa/b) none", "[iri:http://aa/b[none]]"),
+    valid_case_t("url(http://aa/b) currentColor", "[iri:http://aa/b[currentColor]]"),
+    valid_case_t("url(#xxxx)  rgb(11,12,240)", "[iri:#xxxx[rgb:0b0cf0]]"),
+    // These test the removal of surrounding quotes
+    valid_case_t("url(\"http://aa/b\")", "[iri:http://aa/b]"),
+    valid_case_t("url(\"http://aa/b\") none", "[iri:http://aa/b[none]]"),
+    valid_case_t("url(\"http://aa/b\") currentColor", "[iri:http://aa/b[currentColor]]"),
+    valid_case_t("url(\"#xxxx\")  rgb(11,12,240)", "[iri:#xxxx[rgb:0b0cf0]]"),
+  };
+}
+
+class ValidPaint_IE : public ::testing::TestWithParam<valid_case_t> {
+};
+
+TEST_P(ValidPaint_IE, Valid)
+{
+  std::string testStr = GetParam().first;
+  std::string expectedStr = GetParam().second;
+
+  Context ctx;
+  EXPECT_TRUE((value_parser<tag::type::paint, iri_policy<policy::iri::raw> >::parse(
+    tag::attribute::stroke(), ctx, testStr, tag::source::attribute())));
+  EXPECT_EQ(expectedStr, ctx.str());
+}
+
+INSTANTIATE_TEST_CASE_P(value_parser,
+                        ValidPaint_IE,
+                        ::testing::ValuesIn(ValidTests));
+


### PR DESCRIPTION
It appears that IE inserts double quotes around IRI fragments that start with "clipPath" or "filter" when placing SVG data on the clipboard. For example

url(&quot;#filter6393&quot;); 

This confuses svg++ into treating the IRI as an external reference rather than as a fragment. This change strips 0 or 1 double quotes from the beginning and end of an IRI.

This is my first time changing a qi rule, so there may be a better way to do this.