### PR TITLE
Remove deprecated note by using boost/core/scoped_enum.hpp instead of…

### DIFF
--- a/include/svgpp/detail/namespace.hpp
+++ b/include/svgpp/detail/namespace.hpp
@@ -10,7 +10,7 @@
 #ifndef FILE_AF316121_84B7_4A69_BBE7_EEEADDABD0FF_H_
 #define FILE_AF316121_84B7_4A69_BBE7_EEEADDABD0FF_H_
 
-#include <boost/detail/scoped_enum_emulation.hpp>
+#include <boost/core/scoped_enum.hpp>
 #include <boost/preprocessor.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <svgpp/detail/literal_char_types.hpp>


### PR DESCRIPTION
… boost/detail/scoped_enum_emulation.hpp

With Boost 1.74, the notes were:
```
In file included from /usr/include/boost/config/header_deprecated.hpp:18,
                 from /usr/include/boost/detail/scoped_enum_emulation.hpp:15,
                 from /usr/include/svgpp/detail/namespace.hpp:13,
                 from /usr/include/svgpp/detail/attribute_name_to_id.hpp:11,
                 from /usr/include/svgpp/attribute_traversal/prioritized.hpp:12,
                 from /usr/include/svgpp/attribute_traversal/attribute_traversal.hpp:10,
                 from /usr/include/svgpp/document_traversal.hpp:10,
                 from /usr/include/svgpp/svgpp.hpp:1,
...
/usr/include/boost/detail/scoped_enum_emulation.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/scoped_enum.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/scoped_enum.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
...
In file included from /usr/include/boost/config/header_deprecated.hpp:18,
                 from /usr/include/boost/detail/scoped_enum_emulation.hpp:15,
                 from /usr/include/svgpp/detail/namespace.hpp:13,
                 from /usr/include/svgpp/policy/xml/rapidxml_ns.hpp:13,
...
/usr/include/boost/detail/scoped_enum_emulation.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/scoped_enum.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/scoped_enum.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
...
In file included from /usr/include/boost/config/header_deprecated.hpp:18,
                 from /usr/include/boost/detail/scoped_enum_emulation.hpp:15,
                 from /usr/include/svgpp/detail/namespace.hpp:13,
                 from /usr/include/svgpp/detail/attribute_name_to_id.hpp:11,
                 from /usr/include/svgpp/attribute_traversal/prioritized.hpp:12,
                 from /usr/include/svgpp/attribute_traversal/attribute_traversal.hpp:10,
                 from /usr/include/svgpp/document_traversal.hpp:10,
                 from /usr/include/svgpp/svgpp.hpp:1,
...
/usr/include/boost/detail/scoped_enum_emulation.hpp:17:1: note: ‘#pragma message: This header is deprecated. Use <boost/core/scoped_enum.hpp> instead.’
   17 | BOOST_HEADER_DEPRECATED("<boost/core/scoped_enum.hpp>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
```
