### PR TITLE
add .pyc files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/sphinx/_build/
 doc/html/
+*.pyc


### PR DESCRIPTION
@svgpp 

add .pyc files to .gitignore as they keep appearing in the following folders leaving untracked changes:
```
third_party/googletest/googlemock/scripts/generator/cpp/__pycache__/
third_party/googletest/googlemock/test/__pycache__/
```